### PR TITLE
Fix query generation in case of slice of structs

### DIFF
--- a/directus.go
+++ b/directus.go
@@ -300,12 +300,22 @@ func structFields(f reflect.StructField, prefix string) []string {
 				p = tagVal
 			}
 			return iterateFields(f.Type, p)
-
 		}
+	case reflect.Slice:
+		p := prefix
+		if p != "" {
+			p = p + "." + tagVal
+		} else {
+			p = tagVal
+		}
+		if f.Type.Elem().Kind() == reflect.Struct {
+			return iterateFields(f.Type.Elem(), p)
+		}
+		return []string{p}
 	case
 		reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
-		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr, reflect.Float32, reflect.Float64, reflect.String,
-		reflect.Slice, reflect.Map:
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr, reflect.Float32, reflect.Float64,
+		reflect.String, reflect.Map:
 		// field is not nested
 		v := tagVal
 		if prefix != "" {

--- a/directus.go
+++ b/directus.go
@@ -23,6 +23,7 @@ type API[R, W any, PK PrimaryKey] struct {
 	CollectionName string
 	BearerToken    string
 	HTTPClient     *http.Client
+	queryFields    []string
 	debug          bool
 }
 
@@ -249,15 +250,13 @@ func (d API[R, W, PK]) Items(ctx context.Context, q query) ([]R, error) {
 	return respBody.Data, nil
 }
 
-var fieldsR []string
-
-func (d API[R, W, PK]) jsonFieldsR() []string {
-	if fieldsR == nil {
+func (d *API[R, W, PK]) jsonFieldsR() []string {
+	if d.queryFields == nil {
 		var x R
 		t := reflect.TypeOf(x)
-		fieldsR = iterateFields(t, "")
+		d.queryFields = iterateFields(t, "")
 	}
-	return fieldsR
+	return d.queryFields
 }
 
 // iterateFields returns fields for all struct's fields


### PR DESCRIPTION
Recursively iterate through fields if slice of structs is encountered.

```
type OverridesRead struct {
	LimitOverrideProd int `json:"limit_override_prod"`
	LimitOverrideTest int `json:"limit_override_test"`
}

type PartnerTestRead struct {
	EndpointOverrideList []OverridesRead `json:"partner_endpoint_overrides"`
}

type TestRead struct {
	ID      string          `json:"id"`
	Partner PartnerTestRead `json:"partner"`
}
```

Outputs `id,partner.partner_endpoint_overrides`, expected:  `id,partner.partner_endpoint_overrides.limit_override_prod,partner.partner_endpoint_overrides.limit_override_test`